### PR TITLE
Optimization: prevent load associated object

### DIFF
--- a/tm-here-api/grails-app/domain/cn/edu/bnuz/bell/here/dto/TimeslotAttendanceStats.groovy
+++ b/tm-here-api/grails-app/domain/cn/edu/bnuz/bell/here/dto/TimeslotAttendanceStats.groovy
@@ -50,6 +50,6 @@ class TimeslotAttendanceStats implements HibernateEntity<TimeslotAttendanceStats
      * @param rollcall 考勤
      */
     static statsByRollcall(Rollcall rollcall) {
-        findWithSql("select * from sp_get_student_attendance_stats_by_task_schedule_student($rollcall.taskScheduleId, $rollcall.student.id)")
+        findWithSql("select * from sp_get_student_attendance_stats_by_task_schedule_student($rollcall.taskScheduleId, $rollcall.studentId)")
     }
 }

--- a/tm-here-api/grails-app/init/cn/edu/bnuz/bell/tm/here/api/Application.groovy
+++ b/tm-here-api/grails-app/init/cn/edu/bnuz/bell/tm/here/api/Application.groovy
@@ -33,7 +33,7 @@ class Application extends GrailsAutoConfiguration implements EnvironmentAware {
         { ->
             JSON.registerObjectMarshaller(FreeListenSettings) { FreeListenSettings it ->
                 [
-                        term          : it.term.id,
+                        term          : it.termId,
                         applyStartDate: it.applyStartDate,
                         applyEndDate  : it.applyEndDate,
                         checkStartDate: it.checkStartDate,

--- a/tm-here-api/grails-app/services/cn/edu/bnuz/bell/here/FreeListenApprovalService.groovy
+++ b/tm-here-api/grails-app/services/cn/edu/bnuz/bell/here/FreeListenApprovalService.groovy
@@ -161,7 +161,7 @@ order by form.dateSubmitted desc
 
     void accept(AcceptCommand cmd, String userId, UUID workitemId) {
         FreeListenForm form = FreeListenForm.get(cmd.id)
-        domainStateMachineHandler.accept(form, userId, Activities.APPROVE, cmd.comment, workitemId, form.student.id)
+        domainStateMachineHandler.accept(form, userId, Activities.APPROVE, cmd.comment, workitemId, form.studentId.toString())
         form.approver = Teacher.load(userId)
         form.dateApproved = new Date()
         form.save()

--- a/tm-here-api/grails-app/services/cn/edu/bnuz/bell/here/FreeListenCheckService.groovy
+++ b/tm-here-api/grails-app/services/cn/edu/bnuz/bell/here/FreeListenCheckService.groovy
@@ -185,8 +185,8 @@ order by form.dateChecked desc
         domainStateMachineHandler.checkReviewer(id, teacherId, activity)
 
         def termId = form.term as Integer
-        def studentSchedules = freeListenFormService.getStudentSchedules(termId, form.studentId)
-        def departmentSchedules = freeListenFormService.findDepartmentOtherSchedules(form.id)
+        def studentSchedules = freeListenFormService.getStudentSchedules(termId, form.studentId as String)
+        def departmentSchedules = freeListenFormService.findDepartmentOtherSchedules(form.id as Long)
         return [
                 form               : form,
                 studentSchedules   : studentSchedules,

--- a/tm-here-api/grails-app/services/cn/edu/bnuz/bell/here/FreeListenFormService.groovy
+++ b/tm-here-api/grails-app/services/cn/edu/bnuz/bell/here/FreeListenFormService.groovy
@@ -319,11 +319,11 @@ where (courseClass.term.id, courseClass.department.id, course.id) in (
             throw new NotFoundException()
         }
 
-        if (!FreeListenSettings.get(form.term.id).betweenCheckDateRange()) {
+        if (!FreeListenSettings.get(form.termId).betweenCheckDateRange()) {
             throw new BadRequestException()
         }
 
-        if (form.student.id != studentId) {
+        if (form.studentId != studentId) {
             throw new ForbiddenException()
         }
 
@@ -359,7 +359,7 @@ where (courseClass.term.id, courseClass.department.id, course.id) in (
             throw new NotFoundException()
         }
 
-        if (form.student.id != studentId) {
+        if (form.studentId != studentId) {
             throw new ForbiddenException()
         }
 
@@ -381,11 +381,11 @@ where (courseClass.term.id, courseClass.department.id, course.id) in (
             throw new NotFoundException()
         }
 
-        if (!FreeListenSettings.get(form.term.id).betweenCheckDateRange()) {
+        if (!FreeListenSettings.get(form.termId).betweenCheckDateRange()) {
             throw new BadRequestException("Exceed check dates.")
         }
 
-        if (form.student.id != studentId) {
+        if (form.studentId != studentId) {
             throw new ForbiddenException()
         }
 

--- a/tm-here-api/grails-app/services/cn/edu/bnuz/bell/here/RollcallService.groovy
+++ b/tm-here-api/grails-app/services/cn/edu/bnuz/bell/here/RollcallService.groovy
@@ -102,7 +102,7 @@ and taskSchedule.id in (:taskScheduleIds)
             throw new NotFoundException()
         }
 
-        if (rollcall.teacher.id != teacherId) {
+        if (rollcall.teacherId != teacherId) {
             throw new ForbiddenException()
         }
 
@@ -125,7 +125,7 @@ and taskSchedule.id in (:taskScheduleIds)
             throw new NotFoundException()
         }
 
-        if (rollcall.teacher.id != teacherId) {
+        if (rollcall.teacherId != teacherId) {
             throw new ForbiddenException()
         }
 

--- a/tm-here-api/grails-app/services/cn/edu/bnuz/bell/here/StudentLeaveApprovalService.groovy
+++ b/tm-here-api/grails-app/services/cn/edu/bnuz/bell/here/StudentLeaveApprovalService.groovy
@@ -260,7 +260,7 @@ order by form.dateApproved desc
      */
     void accept(String userId, AcceptCommand cmd, UUID workitemId) {
         StudentLeaveForm form = StudentLeaveForm.get(cmd.id)
-        domainStateMachineHandler.accept(form, userId, Activities.APPROVE, cmd.comment, workitemId, form.student.id)
+        domainStateMachineHandler.accept(form, userId, Activities.APPROVE, cmd.comment, workitemId, form.studentId as String)
         form.approver = Teacher.load(userId)
         form.dateApproved = new Date()
         form.save()

--- a/tm-here-api/grails-app/services/cn/edu/bnuz/bell/here/StudentLeaveFormService.groovy
+++ b/tm-here-api/grails-app/services/cn/edu/bnuz/bell/here/StudentLeaveFormService.groovy
@@ -213,7 +213,7 @@ where form.student.id = :studentId
             throw new NotFoundException()
         }
 
-        if (form.student.id != studentId) {
+        if (form.studentId != studentId) {
             throw new ForbiddenException()
         }
 
@@ -251,7 +251,7 @@ where form.student.id = :studentId
             throw new NotFoundException()
         }
 
-        if (form.student.id != studentId) {
+        if (form.studentId != studentId) {
             throw new ForbiddenException()
         }
 
@@ -273,7 +273,7 @@ where form.student.id = :studentId
             throw new NotFoundException()
         }
 
-        if (form.student.id != studentId) {
+        if (form.studentId != studentId) {
             throw new ForbiddenException()
         }
 
@@ -294,7 +294,7 @@ where form.student.id = :studentId
             throw new NotFoundException()
         }
 
-        if (form.student.id != studentId) {
+        if (form.studentId != studentId) {
             throw new ForbiddenException()
         }
 


### PR DESCRIPTION
Replace `a.b.id` with `a.bId` to prevent object loading.